### PR TITLE
use a relative base url

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
 title: The Fast Track to DAML
-baseurl: "/daml-cheat-sheet"
+baseurl: "."
 description: "The Fast Track to DAML - DAML Cheat Sheet"
 github_username: digitalasset
 markdown: kramdown


### PR DESCRIPTION
Setting a relative base URL in the config gives the correct path in the index.html to the css include.