### PR TITLE
DAML Blog link text and target

### DIFF
--- a/_includes/en/Resources.md
+++ b/_includes/en/Resources.md
@@ -1,4 +1,4 @@
 - [Official documentation](https://docs.daml.com)
 - [The Daml code repository](https://github.com/digital-asset/daml)
 - [A Daml project template](https://github.com/digital-asset/create-daml-app)
-- [Read about how people are using Daml on the DAML Blog](https://daml.com/daml-driven)
+- [Read about how people are using Daml on the Daml Blog](https://daml.com/blog)


### PR DESCRIPTION
Daml was capitalized in Daml Blog link and the target was not redirecting to the blog anymore.