### PR TITLE
remove ledger list

### DIFF
--- a/_includes/en/What-is.md
+++ b/_includes/en/What-is.md
@@ -9,13 +9,4 @@ about concrete cryptographic primitives and lets her focus on workflow logic.
 
 Daml is a statically typed functional language.
 
-Applications specified in Daml can be deployed on a growing number of platforms including
-<a href="https://aws.amazon.com/rds/aurora"> Amazon Aurora </a>,
-<a href="https://vmware.github.io/concord-bft"> VMWare Concord </a>,
-<a href="https://www.corda.net">  R3 Corda </a>,
-<a href="https://www.hyperledger.org/projects/fabric"> Hyperledger Fabric </a>,
-<a href="https://sawtooth.hyperledger.org"> Hyperledger Sawtooth </a>,
-<a href="https://projectdabl.com"> Project DABL </a> and <a href="https://www.postgresql.org"> PostgreSQL </a>.
-
-
 The full documentation of Daml can be found <a href="https://docs.daml.com"> here </a>.


### PR DESCRIPTION
Keeping that list on the main docs site is already causing issues (the
desired lifecycle for that information does not match the docs release
cycle), I don't think we should try to maintain a separate copy here.