### PR TITLE
Tweak the type annotation example

### DIFF
--- a/_includes/en/Types.md
+++ b/_includes/en/Types.md
@@ -1,5 +1,5 @@
 | ------------------------ | ------------------------------------------------- |
-| Type annotation          | `var : TypeName`|
+| Type annotation          | `myVar : TypeName`|
 | Builtin types | `Int, Decimal, Numeric n, Text, Bool, Party, Date, Time, RelTime` |
 | Type synonym | `type MyInt = Int` |
 | Lists | `type ListOfInts = [Int]`|


### PR DESCRIPTION
The code `var : TypeName` confused me at first, since `var` is a keyword in other languages. Granted, it should not have confused me. But it did. I think replacing `var` with `myVar` makes the example more clear.