### PR TITLE
Add BigNumeric to the list of Daml types

### DIFF
--- a/_includes/en/Types.md
+++ b/_includes/en/Types.md
@@ -1,6 +1,6 @@
 | ------------------------ | ------------------------------------------------- |
 | Type annotation          | `var : TypeName`|
-| Builtin types | `Int, Decimal, Numeric n, Text, Bool, Party, Date, Time, RelTime` |
+| Builtin types | `Int, Decimal, Numeric n, BigNumeric, Text, Bool, Party, Date, Time, RelTime` |
 | Type synonym | `type MyInt = Int` |
 | Lists | `type ListOfInts = [Int]`|
 | Tuples | `type MyTuple = (Int, Text)` |


### PR DESCRIPTION
I noticed `BigNumeric` was listed [here](https://docs.daml.com/daml/reference/data-types.html).