### PR TITLE
Tweak the examples for Record types

### DIFF
--- a/_includes/en/Data.md
+++ b/_includes/en/Data.md
@@ -1,7 +1,7 @@
 |                      |                                                       |
 | -------------------- | ----------------------------------------------------- |
-| Record | `data Record = Record { label1 : Int, label2 : Text}` |
+| Record | `data MyRecord = MyRecord { label1 : Int, label2 : Text}` |
 | Product type | `data Product = Product Int Text` |
 | Sum type | `data IntOrText = MyInt Int | MyText Text` |
-| Record with type parameters | `data Record a b = Record {label1 : a, label2 : b}` |
-| Deriving Show/Eq instances | `data Record = Record {label : Int} deriving (Show, Eq)` |
+| Record with type parameters | `data MyRecord a b = MyRecord {label1 : a, label2 : b}` |
+| Deriving Show/Eq instances | `data MyRecord = MyRecord {label : Int} deriving (Show, Eq)` |


### PR DESCRIPTION
The tables lists examples of record types. I think the examples are confusing when they also use `Record` as example names. It made me wonder if `Record` was a built-in type or keyword. Perhaps it would be more quickly understandable if we use `MyRecord` instead of `Record`?

This PR replaces #24.